### PR TITLE
Added FnGradioApp to make tabbed interfaces simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,33 @@ demo = fngr.tabbed_interface([
 ```
 
 The main advantage is that it will try to infer the names from the interface.
+
+Or even simpler use `FnGradioApp` for defining interfaces:
+
+```python
+from fngradio import FnGradioApp
+
+
+app = FnGradioApp()
+
+@app.interface()
+def add_int_numbers(a: int, b: int) -> int:
+    """
+    Add two int numbers
+    """
+    return a + b
+
+
+@app.interface()
+def to_upper_case(s) -> str:
+    """
+    Converts text to upper case
+    """
+    return s.upper()
+
+
+demo = app.tabbed()
+
+if __name__ == '__main__':
+    demo.launch(share=False)
+```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ def add_int_numbers(a: int, b: int) -> int:
 
 
 @app.interface()
-def to_upper_case(s) -> str:
+def to_upper_case(s: str) -> str:
     """
     Converts text to upper case
     """

--- a/examples/complex.py
+++ b/examples/complex.py
@@ -4,10 +4,13 @@ from pydantic import Field
 
 import gradio as gr
 
-import fngradio as fngr
+from fngradio import FnGradioApp
 
 
-@fngr.interface()
+app = FnGradioApp()
+
+
+@app.interface()
 def add_int_numbers_with_sliders(
     a: Annotated[int, Field(title="First value", ge=0, le=100)] = 50,
     b: Annotated[int, Field(title="Second value", ge=0, le=100)] = 50
@@ -18,7 +21,7 @@ def add_int_numbers_with_sliders(
     return a + b
 
 
-@fngr.interface()
+@app.interface()
 def add_float_numbers(
     a: Annotated[int, Field(title="First value")],
     b: Annotated[int, Field(title="Second value")]
@@ -29,7 +32,7 @@ def add_float_numbers(
     return a + b
 
 
-@fngr.interface()
+@app.interface()
 def to_upper_case(
     s: Annotated[str, gr.TextArea(label="text", value="Hello")]
 ) -> Annotated[str, gr.TextArea()]:
@@ -39,7 +42,7 @@ def to_upper_case(
     return s.upper()
 
 
-@fngr.interface()
+@app.interface()
 def say(what: Literal["hi", "bye"]) -> str:
     """
     Says Hi! or Bye!
@@ -47,12 +50,7 @@ def say(what: Literal["hi", "bye"]) -> str:
     return "Hi!" if what == "hi" else "Bye!"
 
 
-demo = fngr.tabbed_interface([
-    add_int_numbers_with_sliders,
-    add_float_numbers,
-    to_upper_case,
-    say
-])
+demo = app.tabbed()
 
 
 if __name__ == '__main__':

--- a/fngradio/__init__.py
+++ b/fngradio/__init__.py
@@ -6,3 +6,6 @@ from fngradio.decorators import (  # noqa
 from fngradio.tabbed_interface import (  # noqa
     tabbed_interface
 )
+from fngradio.app import (  # noqa
+    FnGradioApp
+)

--- a/fngradio/app.py
+++ b/fngradio/app.py
@@ -1,0 +1,30 @@
+from typing import Sequence
+
+import gradio as gr
+
+from fngradio.decorators import FnGradio
+from fngradio.tabbed_interface import tabbed_interface
+
+
+class FnGradioApp(FnGradio):
+    def __init__(self) -> None:
+        super().__init__()
+        self._interfaces: list[gr.Interface] = []
+
+    def get_interfaces(self) -> Sequence[gr.Interface]:
+        return self._interfaces
+
+    def _on_interface(self, interface: gr.Interface):
+        super()._on_interface(interface)
+        self._interfaces.append(interface)
+
+    def tabbed(
+        self,
+        tab_names: Sequence[str] | None = None,
+        **kwargs
+    ) -> gr.TabbedInterface:
+        return tabbed_interface(
+            self._interfaces,
+            tab_names=tab_names,
+            **kwargs
+        )

--- a/fngradio/decorators.py
+++ b/fngradio/decorators.py
@@ -131,6 +131,27 @@ class FnGradio:
             )
         raise UnsupportedTypeError(type_hint)
 
+    def _on_interface(self, interface: gr.Interface):  # pylint: disable=redefined-outer-name
+        pass
+
+    def _create_interface(
+        self,
+        fn: Callable,
+        api_name: str,
+        inputs: Sequence[gr.Component],
+        outputs: Sequence[gr.Component],
+        **kwargs
+    ) -> gr.Interface:
+        _interface = gr.Interface(
+            fn=fn,
+            api_name=api_name,
+            inputs=inputs,
+            outputs=outputs,
+            **kwargs
+        )
+        self._on_interface(_interface)
+        return _interface
+
     def interface(
         self,
         *,
@@ -150,7 +171,7 @@ class FnGradio:
             outputs = [
                 self.get_component(hints.get('return'))
             ]
-            return gr.Interface(
+            return self._create_interface(
                 fn=fn,
                 api_name=api_name or fn.__name__,
                 inputs=inputs,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import pytest
+
+import gradio as gr
+
+from fngradio.app import FnGradioApp
+
+
+@pytest.fixture(name='fngr_app')
+def _fngr_app() -> FnGradioApp:
+    return FnGradioApp()
+
+
+class TestFnGradioApp:
+    def test_should_create_gradio_interface_with_simple_type(
+        self,
+        fngr_app: FnGradioApp
+    ):
+        @fngr_app.interface()
+        def fn(s: str) -> str:
+            return s.upper()
+
+        assert fn.input_components and len(fn.input_components) == 1
+        assert isinstance(fn.input_components[0], gr.Textbox)
+        assert len(fn.output_components) == 1
+        assert isinstance(fn.output_components[0], gr.Textbox)
+
+    def test_should_remember_interfaces(
+        self,
+        fngr_app: FnGradioApp
+    ):
+        @fngr_app.interface()
+        def fn(s: str) -> str:
+            return s.upper()
+
+        interfaces = fngr_app.get_interfaces()
+        assert interfaces == [fn]
+
+    def test_should_create_tabbed_interface(
+        self,
+        fngr_app: FnGradioApp
+    ):
+        @fngr_app.interface()
+        def fn(s: str) -> str:
+            return s.upper()
+
+        demo = fngr_app.tabbed()
+        assert isinstance(demo, gr.TabbedInterface)


### PR DESCRIPTION
`FnGradioApp` remembers the interfaces:

```python
from fngradio import FnGradioApp


app = FnGradioApp()

@app.interface()
def add_int_numbers(a: int, b: int) -> int:
    """
    Add two int numbers
    """
    return a + b


@app.interface()
def to_upper_case(s: str) -> str:
    """
    Converts text to upper case
    """
    return s.upper()


demo = app.tabbed()

if __name__ == '__main__':
    demo.launch(share=False)
```
